### PR TITLE
feat: adding support to metrics float value

### DIFF
--- a/internal/shell-exporter/go/collector.go
+++ b/internal/shell-exporter/go/collector.go
@@ -11,7 +11,6 @@ type Collector struct {
 	getDataFunc func(string) ([]shellMetric, error)
 }
 
-//
 type metrics struct {
 	totalScrapes  prometheus.Counter
 	failedScrapes prometheus.Counter
@@ -19,7 +18,7 @@ type metrics struct {
 }
 
 type shellMetric struct {
-	Value  int               `json:"value"`
+	Value  float64           `json:"value"`
 	Labels map[string]string `json:"labels"`
 }
 

--- a/metrics/bash_gauge.sh
+++ b/metrics/bash_gauge.sh
@@ -30,3 +30,6 @@ for i in $(seq 1 10)
 do
     add_gauge_vector ${RANDOM} "for_${i}"
 done
+
+add_gauge_vector 1.5 "float_1.5"
+add_gauge_vector 0.5 "float_0.5"


### PR DESCRIPTION
on eof my uses cases need the metrics value to be float, once the prometheus parser is setup for this format but the shell parser is not this little change adds support to float64

unit tests were run on linux only